### PR TITLE
fix: playground issue due to v5 helmetjs

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -44,7 +44,9 @@ const app = express();
   // Read more at https://expressjs.com/en/guide/behind-proxies.html
   app.set('trust proxy', true);
 
-  app.use(helmet({ contentSecurityPolicy: false }));
+  // https://github.com/graphql/graphql-playground/issues/1283#issuecomment-1012913186
+  app.use(helmet({ contentSecurityPolicy: false, crossOriginEmbedderPolicy: false }));
+
   app.use(cookieParser());
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));


### PR DESCRIPTION
Might not be the best solution as CSP is disabled. I think the assets that playground needs should be served by us and not via CDN but that needs to be adjusted upstream so we have no control over it.